### PR TITLE
homepage FE fixed

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -44,7 +44,7 @@
 }
 
 .button-wrapper-feedback {
-  width: 100%;
+  // width: 100%;
   display: flex;
   justify-content: flex-end;
   position: relative;
@@ -53,6 +53,60 @@
 .btn-shadow-feedback {
   display: block;
   content: 'Send feedback';
+  padding: 0.5em 3em;
+  border: 0.12em solid #000000;
+  box-sizing: border-box;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: 'Roboto',sans-serif;
+  font-weight: 700;
+  font-size: 12px;
+  color: #000000;
+  text-align: center;
+  z-index: -1;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}
+
+.btn-send-follow {
+  display: inline-block;
+  padding: 0.5em 3em;
+  border: 0.12em solid #000000;
+  box-sizing: border-box;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  font-family: 'Roboto',sans-serif;
+  font-weight: 700;
+  font-size: 12px;
+  color: #000000;
+  text-align: center;
+  transition: all 0.15s;
+  background-color: #D7ECFF;
+  position: absolute;
+}
+
+.btn-send-follow:hover {
+  top: 5px;
+  right: 5px;
+}
+
+.btn-send-follow:active {
+  background-color: darken(#D7ECFF, 10%);
+}
+
+.button-wrapper-follow {
+  // width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+}
+
+.btn-shadow-follow {
+  display: block;
+  content: 'Follow';
   padding: 0.5em 3em;
   border: 0.12em solid #000000;
   box-sizing: border-box;

--- a/app/assets/stylesheets/pages/_brandguidelines.scss
+++ b/app/assets/stylesheets/pages/_brandguidelines.scss
@@ -211,7 +211,7 @@ p.centered-content {
   font-size: 20px;
   line-height: 26px;
   text-align: center;
-  width: 600px;
+  // width: 600px;
 }
 
 /* Top Description Section */

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -1,9 +1,9 @@
-p.centered-content {
-  font-family: Roboto, sans-serif;
-  font-style: normal;
-  font-weight: normal;
-  font-size: 18px;
-  line-height: 26px;
-  text-align: center;
-  width: 600px;
-}
+// p.centered-content {
+//   font-family: Roboto, sans-serif;
+//   font-style: normal;
+//   font-weight: normal;
+//   font-size: 18px;
+//   line-height: 26px;
+//   text-align: center;
+//   // width: 600px;
+// }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,7 +9,11 @@ class CommentsController < ApplicationController
     @comment.artwork = @artwork
     @comment.user = current_user
     @comment.save
-    redirect_to artwork_path
+    if params[:coming_from] == "show"
+      redirect_to @artwork
+    else
+      redirect_to root_path(@artwork, new_comment_id: @comment.id, anchor: "artwork-image-#{@artwork.id}")
+    end
   end
 
   def create_index

--- a/app/views/artworks/_artworks_card.html.erb
+++ b/app/views/artworks/_artworks_card.html.erb
@@ -2,8 +2,9 @@
   <div class="row justify-content-center">
     <div class="col-sm-9 mt-5">
       <a href="<%= artwork_path(artwork) %>" class="hover-img-container">
-      <% if artwork.photos.present? %>
-        <%= cl_image_tag artwork.photos.first.key, class: 'center-img', alt: "artwork", id: "artwork-image-#{artwork.id}" %>      <% end %>
+        <% if artwork.photos.present? %>
+          <%= cl_image_tag artwork.photos.first.key, class: 'center-img', alt: "artwork", id: "artwork-image-#{artwork.id}" %>
+        <% end %>
         <div class="overlay">
           @<%= artwork.user.username %><br>
           <%= artwork.title %>

--- a/app/views/artworks/_comment_form.html.erb
+++ b/app/views/artworks/_comment_form.html.erb
@@ -1,6 +1,10 @@
 <%= simple_form_for [@artwork, @comment], html: { class: 'd-flex flex-column flex-grow-1' } do |f| %>
   <%= f.input :content, input_html: { class: 'flex-grow-1' }, placeholder: 'What would you like to say about this piece?', label: false %>
+  <div class="button-wrapper-feedback">
+    <%= f.submit value: "Send feedback", class: 'btn-send-feedback justify-content-center mb-3 send-feedback', 'data-disable-with' => "Send feedback" %>
+    <a href="#" class="btn-shadow-feedback">Send feedback</a>
+  </div>
+  <%= hidden_field_tag :coming_from, action_name %>
   <%= f.input :x_offset, as: :hidden %>
   <%= f.input :y_offset, as: :hidden %>
-  <%= f.button :submit, input_html: { class: 'justify-content-center, mb-3' } %>
 <% end %>

--- a/app/views/artworks/show.html.erb
+++ b/app/views/artworks/show.html.erb
@@ -1,26 +1,28 @@
 <div class="container">
-   <div class="d-flex mt-5">
-    <% if @artwork.user.photo.key %>
-      <%= cl_image_tag @artwork.user.photo.key, class: 'profile' %>
-    <% end %>
-    <div class="container ml-3 top-description">
-      <h1><%= @artwork.title %> </h1>
-      <p>@<%= link_to @artwork.user.username, profile_path(@artwork.user) %></p>
-    </div>
-    <div class="button-wrapper">
-      <a href="#" class="button-primary-shadow">Follow</a>
-      <a href="#" class="button-shadow">Follow</a>
+  <div class="col-m-12">
+    <div class="d-flex mt-5">
+      <% if @artwork.user.photo.key %>
+        <%= cl_image_tag @artwork.user.photo.key, class: 'profile' %>
+      <% end %>
+      <div class="flex-grow-1 mx-3 top-description">
+        <h1><%= @artwork.title %> </h1>
+        <p>@<%= link_to @artwork.user.username, profile_path(@artwork.user) %></p>
+      </div>
+      <div class="button-wrapper-follow">
+        <a href="#" class="btn-send-follow">Follow</a>
+        <a href="#" class="btn-shadow-follow">Follow</a>
+      </div>
     </div>
   </div>
 
-  <div class="d-flex justify-content-center">
+  <div class="d-flex justify-content-center m-3">
     <p class="centered-content"><%= @artwork.description %></p>
   </div>
 
   <div class="d-flex justify-content-center">
     <% @artwork.photos.each do |image|%>
       <div class="image-wrapper">
-        <%= cl_image_tag image.key, class: 'mt-3 mb-3', :alt => "artwork", id: "artwork", style: 'object-fit: cover; max-width: 1200px; max-height: 1200px' %>
+        <%= cl_image_tag image.key, class: 'mt-3 mb-3', :alt => "artwork", id: "artwork", style: 'object-fit: cover; max-width: 1200px; max-height: 95vh' %>
         <% @marked_comments.each do |comment| %>
           <i class="fas fa-comment marker artwork", style="top: <%= comment.y_offset%>px; left: <%=comment.x_offset%>px"></i>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,10 @@ Rails.application.routes.draw do
   get '/share', to: 'pages#share'
   get '/brandguidelines', to: 'pages#brandguidelines'
   get '/landing', to: 'pages#landing'
-  post '/artworks/:artwork_id/comments', to: 'comments#create_index', as: 'create_comments_index'
   resources :users, only: :show
   resources :artworks, only: [:index, :new, :create, :show] do
     resources :comments, only: [:create]
   end
+  post '/artworks/:artwork_id/comments', to: 'comments#create_index', as: 'create_comments_index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
• Artwork title field flex-grow'd
• Follow button styling implemented via new set of CSS styles (refactoring may be needed)
• Styled button implement for submit
• Fixed bug where adding a comment on the show page redirected the user to the home page
• Description field widened
• Artwork given 95vh to allow users to see the artwork in its entirety in one screen (may have to be adjusted for artworks in portrait)

BUG:
• Follow button now becomes blue and underlined on hover, but this may be automatically fixed once the follow functionality is applied